### PR TITLE
Refactor/create team ddl division

### DIFF
--- a/WMBA5/WMBA5/Controllers/PlayerController.cs
+++ b/WMBA5/WMBA5/Controllers/PlayerController.cs
@@ -20,7 +20,7 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace WMBA5.Controllers
 {
-    [Authorize(Roles = "Admin, Rookie Convenor, Intermediate Convenor, Senior Convenor, Trash Pandas 15U Coach, Trash Pandas 15U Scorekeeper, Scorekeeper, Coach")]
+    [Authorize(Roles = "Admin, Rookie Convenor, Intermediate Convenor, Senior Convenor, Trash Pandas 15U Coach, Coach")]
     public class PlayerController : ElephantController
     {
         private readonly WMBAContext _context;

--- a/WMBA5/WMBA5/Controllers/TeamController.cs
+++ b/WMBA5/WMBA5/Controllers/TeamController.cs
@@ -169,8 +169,20 @@ namespace WMBA5.Controllers
         [Authorize(Roles = "Admin, Rookie Convenor, Intermediate Convenor, Senior Convenor")]
         public IActionResult Create()
         {
+            if (User.IsInRole("Rookie Convenor"))
+            {
+                ViewData["DivisionID"] = new SelectList(_context.Divisions.Where(d => d.DivisionName == "9U"), "ID", "DivisionName");
+            }
+            if (User.IsInRole("Intermediate Convenor"))
+            {
+                ViewData["DivisionID"] = new SelectList(_context.Divisions.Where(d => d.DivisionName == "11U" || d.DivisionName =="13U"), "ID", "DivisionName");
+            }
+            if (User.IsInRole("Senior Convenor"))
+            {
+                ViewData["DivisionID"] = new SelectList(_context.Divisions.Where(d => d.DivisionName == "15U" || d.DivisionName == "18U"), "ID", "DivisionName");
+            }
             ViewData["CoachID"] = new SelectList(_context.Coaches, "ID", "CoachName");
-            ViewData["DivisionID"] = new SelectList(_context.Divisions, "ID", "DivisionName");
+            
             return View();
         }
 
@@ -190,6 +202,7 @@ namespace WMBA5.Controllers
                     await _context.SaveChangesAsync();
                     return RedirectToAction(nameof(Index));
                 }
+                
                 ViewData["CoachID"] = new SelectList(_context.Coaches, "ID", "CoachName", team.CoachID);
                 ViewData["DivisionID"] = new SelectList(_context.Divisions, "ID", "DivisionName", team.DivisionID);
             }

--- a/WMBA5/WMBA5/Controllers/TeamController.cs
+++ b/WMBA5/WMBA5/Controllers/TeamController.cs
@@ -17,7 +17,7 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace WMBA5.Controllers
 {
-    [Authorize(Roles = "Admin, Rookie Convenor, Intermediate Convenor, Senior Convenor, Trash Pandas 15U Coach, Trash Pandas 15U Scorekeeper, Scorekeeper, Coach")]
+    [Authorize(Roles = "Admin, Rookie Convenor, Intermediate Convenor, Senior Convenor, Trash Pandas 15U Coach, Coach")]
     public class TeamController : ElephantController
     {
         private readonly WMBAContext _context;

--- a/WMBA5/WMBA5/Views/Home/Index.cshtml
+++ b/WMBA5/WMBA5/Views/Home/Index.cshtml
@@ -35,7 +35,7 @@
     }
    @*  Every user that has a role will be able to see it, users that login but dont have a role wont be able to see this *@
     @{
-        if (User.IsInRole("Admin") || User.IsInRole("Rookie Convenor") || User.IsInRole("Intermediate Convenor") || User.IsInRole("Senior Convenor") || User.IsInRole("Trash Pandas 15U Coach") || User.IsInRole("Trash Pandas 15U Scorekeeper") || User.IsInRole("Scorekeeper") || User.IsInRole("Coach"))
+        if (User.IsInRole("Admin") || User.IsInRole("Rookie Convenor") || User.IsInRole("Intermediate Convenor") || User.IsInRole("Senior Convenor") || User.IsInRole("Trash Pandas 15U Coach") || User.IsInRole("Coach"))
         {
             <div class="main-grid-item">
                 <div class="card">
@@ -61,6 +61,12 @@
                 </div>
             </div>
 
+        }
+    }
+    @{
+        if (User.IsInRole("Admin") || User.IsInRole("Rookie Convenor") || User.IsInRole("Intermediate Convenor") || User.IsInRole("Senior Convenor") || User.IsInRole("Trash Pandas 15U Coach") || User.IsInRole("Trash Pandas 15U Scorekeeper") || User.IsInRole("Scorekeeper") || User.IsInRole("Coach"))
+        {
+           
             <div class="main-grid-item">
                 <div class="card">
                     <h3>Games </h3>

--- a/WMBA5/WMBA5/Views/Shared/_Layout.cshtml
+++ b/WMBA5/WMBA5/Views/Shared/_Layout.cshtml
@@ -31,7 +31,7 @@
                             }
                         }
                         @{
-                            if (User.IsInRole("Admin") || User.IsInRole("Rookie Convenor") || User.IsInRole("Intermediate Convenor") || User.IsInRole("Senior Convenor") || User.IsInRole("Trash Pandas 15U Coach") || User.IsInRole("Trash Pandas 15U Scorekeeper") || User.IsInRole("Scorekeeper") || User.IsInRole("Coach"))
+                            if (User.IsInRole("Admin") || User.IsInRole("Rookie Convenor") || User.IsInRole("Intermediate Convenor") || User.IsInRole("Senior Convenor") || User.IsInRole("Trash Pandas 15U Coach") || User.IsInRole("Coach"))
                             {
                                 <li class="nav-item item-nav">
                                     <a class="nav-link" style="color:#E7E7E7; padding:10px;" asp-area="" asp-controller="Player" asp-action="Index">Players</a>
@@ -39,6 +39,12 @@
                                 <li class="nav-item item-nav">
                                     <a class="nav-link " style="color:#E7E7E7; padding:10px;" asp-area="" asp-controller="Team" asp-action="Index">Teams</a>
                                 </li>
+                                
+                            }
+                        }
+                        @{
+                            if (User.IsInRole("Admin") || User.IsInRole("Rookie Convenor") || User.IsInRole("Intermediate Convenor") || User.IsInRole("Senior Convenor") || User.IsInRole("Trash Pandas 15U Coach") || User.IsInRole("Trash Pandas 15U Scorekeeper") || User.IsInRole("Scorekeeper") || User.IsInRole("Coach"))
+                            {
                                 <li class="nav-item item-nav">
                                     <a class="nav-link " style="color:#E7E7E7; padding:10px;" asp-area="" asp-controller="Game" asp-action="Index">Games</a>
                                 </li>


### PR DESCRIPTION
Added a team to the 13U division, the Rookie convenor manages 9U only and should not be able to add a team to 13U. (Subit, I will let you know if I need help here)

Fixed, added a couple of lines for the get option in create action an now Rookie convenors can only create a team in 9U, intermediate for 11U and 13U and Senior for 15U and 18U